### PR TITLE
tapvid3d: add extrinsics_w2c in adt output

### DIFF
--- a/tapnet/tapvid3d/annotation_generation/adt_utils.py
+++ b/tapnet/tapvid3d/annotation_generation/adt_utils.py
@@ -171,6 +171,7 @@ def process_vid(
     queries_xyt = in_npz["queries_xyt"]
     trajectories = in_npz["tracks_XYZ"]
     visibilities = in_npz["visibility"]
+    extrinsics = in_npz["extrinsics_w2c"]
 
     # Verify video means.
     video_means = np.stack([np.mean(x, axis=(0, 1)) for x in rgb_ims], axis=0)
@@ -184,5 +185,6 @@ def process_vid(
         "fx_fy_cx_cy": np.array(
             [FOCAL_LENGTH, FOCAL_LENGTH, WIDTH / 2, HEIGHT / 2]
         ),
+        "extrinsics_w2c": extrinsics,
     }
     np.savez(track_fn, **example)


### PR DESCRIPTION
As stated in the [README](https://github.com/google-deepmind/tapnet/blob/main/tapnet/tapvid3d/README.md?plain=1#L108), the output .npz files for tapvid3d should include also a 'extrinsics_w2c' key for camera extrinsics. 

The current processing script for ADT does not save extrinsics data from the temporary input .npz files to the final output .npz files.

With this PR, the 'extrinsics_w2c' field is added also to output .npz files

(Related to #115 ?)